### PR TITLE
Add ServiceEntry to the scheme

### DIFF
--- a/pkg/apis/networking/v1alpha3/register.go
+++ b/pkg/apis/networking/v1alpha3/register.go
@@ -52,6 +52,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&DestinationRuleList{},
 		&Sidecar{},
 		&SidecarList{},
+		&ServiceEntry{},
+		&ServiceEntrylist{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil


### PR DESCRIPTION
The implementation does not work properly for SEs.  This small
change adds ServiceEntry and ServiceEntryList to the scheme.